### PR TITLE
Fix jstestdriver.jar path

### DIFF
--- a/tasks/jstestdriver.js
+++ b/tasks/jstestdriver.js
@@ -108,7 +108,7 @@ module.exports = function (grunt) {
             cp = grunt.util.spawn({
                 cmd: 'java',
                 args: ["-jar",
-                       'lib/jstestdriver.jar',
+                       __dirname + '/../lib/jstestdriver.jar',
                        "--config",
                        configFileLocation].concat(getOptionsArray(options))
             }, processed);


### PR DESCRIPTION
The task wasn't finding jstestdriver.jar when included with loadNpmTasks
