### PR TITLE
mkdir testOutput directory if it don't exist

### DIFF
--- a/tasks/jstestdriver.js
+++ b/tasks/jstestdriver.js
@@ -122,6 +122,10 @@ module.exports = function (grunt) {
         if (typeof config.files === 'string') {
             config.files = [config.files];
         }
+        
+        if (options.testOutput) {
+            grunt.file.mkdir(options.testOutput);
+        }
 
         numberOfConfigs = config.files.length;
 


### PR DESCRIPTION
Would be more convenient for me, currently I register a task in my Grunt file.

```
grunt.registerTask('unit-tests', function () {
    grunt.file.mkdir('build/tests');
    grunt.task.run('jstestdriver');
});
```

Thanks
