### PR TITLE
Parse errors as well as add tests that error out to the logging output.

### DIFF
--- a/tasks/jstestdriver.js
+++ b/tasks/jstestdriver.js
@@ -21,6 +21,7 @@ module.exports = function (grunt) {
             numberOfConfigs,
             numberOfPassedTests = 0,
             numberOfFailedTests = 0,
+            numberOfErrorTests = 0,
             failedTests = [];
 
         grunt.verbose.writeflags(options, 'Options');
@@ -31,7 +32,8 @@ module.exports = function (grunt) {
                 done(false);
             } else {
                 grunt.log.ok('Total Passed: ' +
-                    numberOfPassedTests + ', Fails: ' + numberOfFailedTests);
+                    numberOfPassedTests + ', Fails: ' + numberOfFailedTests +
+                    ', Errors: ' + numberOfErrorTests);
                 done();
             }
         }
@@ -40,13 +42,16 @@ module.exports = function (grunt) {
             var cp;
 
             function setNumberOfPassesAndFails(result) {
+                // The result string looks like this:
+                // Passed: 114; Fails: 0; Errors: 0
                 var resultAsStr = result.toString(),
-                    passedReg = /\d+(?=;\sFails)/,
-                    failsReg = /\d+(?=;\sErrors)/;
+                    resultReg = /Passed: (\d+); Fails: (\d+); Errors: (\d+)/,
+                    parsedResult = resultReg.exec(resultAsStr);
 
                 if (resultAsStr && resultAsStr.indexOf('RuntimeException') === -1) {
-                    numberOfPassedTests += parseInt(passedReg.exec(resultAsStr)[0], 10);
-                    numberOfFailedTests += parseInt(failsReg.exec(resultAsStr)[0], 10);
+                    numberOfPassedTests += parseInt(parsedResult[1], 10);
+                    numberOfFailedTests += parseInt(parsedResult[2], 10);
+                    numberOfErrorTests  += parseInt(parsedResult[3], 10);
                 } else {
                     grunt.fail.fatal('Did you start your server?\n' + resultAsStr);
                 }


### PR DESCRIPTION
My first pull request against a public repo, so if I commit a massive faux pas please let me know.

This pull request adds errored out test parsing and logging. It also improves the parsing robustness of the regex that extracts the passed/failed tests. It was failing for me on the following example: 

```
Passed: 114; Fails: 0; Errors: 0
```

The previous regexp was just reporting 4 test instead of 114.
