### PR TITLE
Multiple configs fixed

### DIFF
--- a/tasks/jstestdriver.js
+++ b/tasks/jstestdriver.js
@@ -18,7 +18,6 @@ module.exports = function (grunt) {
             }),
             config = grunt.config.get('jstestdriver'),
             done = this.async(),
-            numberOfConfigs,
             numberOfPassedTests = 0,
             numberOfFailedTests = 0,
             failedTests = [];
@@ -36,7 +35,7 @@ module.exports = function (grunt) {
             }
         }
 
-        function runJSTestDriver(configFileLocation, options) {
+        function runJSTestDriver(configFileLocation, options, processNext) {
             var cp;
 
             function setNumberOfPassesAndFails(result) {
@@ -68,10 +67,7 @@ module.exports = function (grunt) {
                 grunt.log.verbose.writeln('>> Finished running file: ' + configFileLocation);
                 grunt.log.verbose.writeln('');
 
-                numberOfConfigs -= 1;
-                if (numberOfConfigs === 0) {
-                    taskComplete();
-                }
+                processNext();
             }
 
             function processed(error, result) {
@@ -131,11 +127,9 @@ module.exports = function (grunt) {
             grunt.file.mkdir(options.testOutput);
         }
 
-        numberOfConfigs = config.files.length;
-
-        grunt.util.async.forEach(config.files, function (filename) {
-            runJSTestDriver(filename, options);
-        }.bind(this));
+        grunt.util.async.forEachSeries(config.files, function (filename, processNext) {
+            runJSTestDriver(filename, options, processNext);
+        }.bind(this), taskComplete);
     });
 
 };


### PR DESCRIPTION
This fix resolves a race condition that occurs when multiple config files have been specified. JSTestDriver reports unwanted errors when more than one test process is trying to access the same source or test files.

Changes:
- Spawning the next jsTestDriver process only after the previous one has finished
- Removed config counter as it was used solely for detecting the end of the iteration and `grunt.utils.async` has this feature built in
